### PR TITLE
feat: show RSS downtime in status

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,10 +154,24 @@ def api_login():
 
 @app.route('/api/status')
 def api_status():
-    """Endpoint to check token validity"""
+    """Endpoint to report basic system status"""
     if not verify_api_token():
         return jsonify({"error": "Authentication required"}), 401
-    return jsonify({"status": "ok"}), 200
+
+    rss_status = "ok"
+    try:
+        with open(FEEDS_FILE, 'r') as f:
+            first_feed = next((line.strip() for line in f if line.strip()), None)
+        if not first_feed:
+            rss_status = "missing"
+        else:
+            resp = requests.get(first_feed, timeout=5)
+            if not resp.ok:
+                rss_status = "down"
+    except Exception:
+        rss_status = "down"
+
+    return jsonify({"status": "ok", "rssService": rss_status}), 200
     
 @app.route('/api/reset-summary', methods=['POST'])
 def api_reset_summary():

--- a/bot/main.py
+++ b/bot/main.py
@@ -112,6 +112,23 @@ def save_seen_guids(guids):
     with open(SEEN_FILE, 'w') as f:
         json.dump(list(guids)[-500:], f, indent=2)  # Keep last 500 posts
 
+async def check_rss_service() -> bool:
+    """Quickly check if the first feed URL is reachable."""
+    try:
+        with open(os.path.join(BASE_DIR, 'feeds.txt'), 'r') as f:
+            feed_url = next((line.strip() for line in f if line.strip()), None)
+    except Exception:
+        feed_url = None
+
+    if not feed_url:
+        return False
+
+    try:
+        async with HTTP_SESSION.get(feed_url, timeout=10) as resp:
+            return resp.status < 500
+    except Exception:
+        return False
+
 async def build_full_body(entry: dict) -> str:
     """Build full formatted body for an entry using existing logic."""
     maybe_update(entry)
@@ -485,6 +502,16 @@ async def run_bot_job():
     @client.event
     async def on_ready():
         print(f"Logged in as {client.user} to perform job.")
+        rss_ok = await check_rss_service()
+        status_text = "feeds active" if rss_ok else "RSS service offline"
+        try:
+            await client.change_presence(activity=discord.Activity(
+                type=discord.ActivityType.watching,
+                name=status_text
+            ))
+        except Exception as e:
+            print(f"Presence update failed: {e}")
+
         await process_feeds_once(client)
         print("Job complete. Logging out.")
         await client.close()

--- a/docs/index.html
+++ b/docs/index.html
@@ -236,6 +236,20 @@
         metadata = data.metadata || {};
         groups = data.groups || {};
         mappings = data.mappings || {};
+
+        // Fetch system status to update service indicator
+        try {
+          const statusResp = await fetch(`${API_BASE}/api/status`);
+          if (statusResp.ok) {
+            const status = await statusResp.json();
+            document.getElementById('system-status').textContent =
+              status.rssService === 'ok' ? '🟢 Online' : '🔴 Offline';
+          } else {
+            document.getElementById('system-status').textContent = '⚠️ Unknown';
+          }
+        } catch (e) {
+          document.getElementById('system-status').textContent = '⚠️ Unknown';
+        }
         channels = data.channels || [];
         lastUpdate = data.last_update || null;
         
@@ -468,7 +482,6 @@
           label.removeAttribute('title');
         }
       }
-      document.getElementById('system-status').textContent = feeds.length > 0 ? '🟢 Online' : '🔴 Offline';
     }
 
     // Helper functions


### PR DESCRIPTION
## Summary
- expose RSS service health via `/api/status`
- show RSS availability in Discord presence
- display RSS service status on public index page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896293e14c0832da8dbd405ae9d15c6